### PR TITLE
new release v0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG for dhcp
 
+## 0.2.2:
+
+* Change service to enabled/start so does not stop when no new template data
+
 ## 0.2.1:
 
 * Added Support for Ubuntu 14.04 (pulled from the v1.0.0 unreleased tag)

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,5 +4,5 @@ maintainer_email 'kglueck@viz.tamu.edu'
 license          'MIT'
 description      'Installs/Configures dhcp server'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.2.1'
+version          '0.2.2'
 supports 'ubuntu', '>= 12.04'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -46,5 +46,5 @@ template ::File.join(node[:dhcp][:dhcp_dir], 'dhcpd.pools') do
 end
 
 service node[:dhcp][:service_name] do
-  action [:disable, :stop]
+  action [:enable, :start]
 end


### PR DESCRIPTION
When there are changes in the data bag for the templates to write out, we tag a `:restart` on the end of the service line (basically).  However, when there isn't new stuff to write we were shutting down the service, which is bad.